### PR TITLE
[config] 프로젝트 초기 공통 설정 및 실행 환경 구성

### DIFF
--- a/mypawday/.env.example
+++ b/mypawday/.env.example
@@ -1,0 +1,13 @@
+########################################
+# Database (PostgreSQL)
+########################################
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=mypawday
+DB_USERNAME=mypawday
+DB_PASSWORD=mypawday
+
+########################################
+# Swagger
+########################################
+SWAGGER_ENABLED=true

--- a/mypawday/build.gradle
+++ b/mypawday/build.gradle
@@ -25,6 +25,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	compileOnly 'org.projectlombok:lombok'

--- a/mypawday/compose.yaml
+++ b/mypawday/compose.yaml
@@ -1,9 +1,12 @@
 services:
   postgres:
-    image: 'postgres:latest'
-    environment:
-      - 'POSTGRES_DB=mydatabase'
-      - 'POSTGRES_PASSWORD=secret'
-      - 'POSTGRES_USER=myuser'
+    image: postgres:18
+    container_name: postgres-mypawday
+    restart: unless-stopped
     ports:
-      - '5432'
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: mypawday
+      POSTGRES_USER: mypawday
+      POSTGRES_PASSWORD: mypawday
+      TZ: Asia/Seoul

--- a/mypawday/src/main/java/com/tico/mypawday/global/config/swagger/SwaggerConfig.java
+++ b/mypawday/src/main/java/com/tico/mypawday/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.tico.mypawday.global.config.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("My PawDay API")
+                        .description("멍냥의 하루(My PawDay) 서비스 API 문서")
+                        .version("v1.0.0"));
+    }
+}

--- a/mypawday/src/main/resources/application-datasource.yaml
+++ b/mypawday/src/main/resources/application-datasource.yaml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:mypawday}
+    username: ${DB_USERNAME:mypawday}
+    password: ${DB_PASSWORD:mypawday}
+
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+    properties:
+      hibernate:
+        format_sql: true

--- a/mypawday/src/main/resources/application-swagger.yaml
+++ b/mypawday/src/main/resources/application-swagger.yaml
@@ -1,0 +1,9 @@
+springdoc:
+  api-docs:
+    enabled: ${SWAGGER_ENABLED:true}
+
+  swagger-ui:
+    enabled: ${SWAGGER_ENABLED:true}
+    operations-sorter: method
+    tags-sorter: alpha
+    display-request-duration: true

--- a/mypawday/src/main/resources/application.yaml
+++ b/mypawday/src/main/resources/application.yaml
@@ -1,3 +1,8 @@
 spring:
   application:
     name: mypawday
+
+  profiles:
+    include:
+      - datasource
+      - swagger


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
#45

<br>

## 📌 개요
- 프로젝트 초기 개발을 위한 공통 설정을 구성했습니다.
- 데이터베이스, Swagger 문서, 로컬 실행 환경을 설정하여 개발 기반을 마련했습니다.

<br>

## 🔁 변경 사항
- PostgreSQL datasource 설정 추가
- JPA 기본 설정 추가 (`ddl-auto: none`, `open-in-view: false`)
- Swagger(OpenAPI) 문서 설정 추가 및 환경변수 기반 ON/OFF 구성
- PostgreSQL 로컬 실행을 위한 Docker Compose 파일 추가
- 로컬 실행 가이드를 위한 `.env.example` 템플릿 추가

<br>

## 👀 기타 더 이야기해볼 점
- 현재는 단일 환경 기준 설정이며, 추후 `local / prod` 프로파일 분리를 고려하고 있습니다.
