### PR TITLE
[feat] 공통 BaseEntity 추가 및 논리 삭제 구조 구현

### DIFF
--- a/mypawday/src/main/java/com/tico/mypawday/MypawdayApplication.java
+++ b/mypawday/src/main/java/com/tico/mypawday/MypawdayApplication.java
@@ -2,7 +2,9 @@ package com.tico.mypawday;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MypawdayApplication {
 

--- a/mypawday/src/main/java/com/tico/mypawday/global/entity/BaseEntity.java
+++ b/mypawday/src/main/java/com/tico/mypawday/global/entity/BaseEntity.java
@@ -1,0 +1,48 @@
+package com.tico.mypawday.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void delete() {
+        if (isDeleted()) {
+            return;
+        }
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        if (!isDeleted()) {
+            return;
+        }
+        this.deletedAt = null;
+    }
+}


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
- #50 
- #49 

<br>

## 📌 개요
- 전 도메인에서 공통으로 사용할 BaseEntity를 추가했습니다.
- 생성/수정 시간 관리와 논리 삭제(Soft Delete)를 공통으로 처리할 수 있는 기반 구조를 구현했습니다.
- JPA Auditing을 고려한 베이스 엔티티로, 이후 모든 엔티티가 일관된 생명주기를 가지도록 설계했습니다.

<br>

## 🔁 변경 사항
- 공통 BaseEntity 추가
  - createdAt, updatedAt 공통 필드 정의
  - deletedAt 기반 논리 삭제 구조 구현
- 엔티티 직접 생성을 제한하기 위한 protected 기본 생성자 적용
- 전 도메인에서 상속하여 사용할 수 있는 공통 엔티티 구조 정리
<br>

## 👀 기타 더 이야기해볼 점
