### PR TITLE
[feat] 반려동물(Pet) 도메인 엔티티 구현

### DIFF
--- a/mypawday/src/main/java/com/tico/mypawday/pet/domain/entity/Breed.java
+++ b/mypawday/src/main/java/com/tico/mypawday/pet/domain/entity/Breed.java
@@ -1,9 +1,12 @@
 package com.tico.mypawday.pet.domain.entity;
 
+import com.tico.mypawday.pet.domain.vo.Species;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 /**
  * 반려동물 품종 엔티티
@@ -16,6 +19,19 @@ public class Breed {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "breed_id")
+    @Column(name = "breed_id", nullable = false, updatable = false)
     private Long breedId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "species", nullable = false, length = 10)
+    private Species species;
+
+    @Column(name = "name", nullable = false, length = 50)
+    private String name;
+
+    @Column(name = "active", nullable = false)
+    private boolean active = true;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 }

--- a/mypawday/src/main/java/com/tico/mypawday/pet/domain/entity/Pet.java
+++ b/mypawday/src/main/java/com/tico/mypawday/pet/domain/entity/Pet.java
@@ -1,10 +1,15 @@
 package com.tico.mypawday.pet.domain.entity;
 
+import com.tico.mypawday.global.entity.BaseEntity;
+import com.tico.mypawday.pet.domain.vo.Gender;
+import com.tico.mypawday.pet.domain.vo.Species;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.UUID;
 
 /**
@@ -14,10 +19,46 @@ import java.util.UUID;
 @Entity
 @Table(name = "p_pets")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Pet {
+public class Pet extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "pet_id")
+    @Column(name = "pet_id", nullable = false, updatable = false)
     private UUID petId;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private UUID userId;
+
+    @Column(name = "name", nullable = false, length = 15)
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "species", nullable = false, length = 10)
+    private Species species;
+
+    @Column(name = "breed_id")
+    private Long breedId;
+
+    // breed_id가 NULL일 때만 사용
+    @Column(name = "custom_breed", length = 50)
+    private String customBreed;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gender", nullable = false, length = 10)
+    private Gender gender;
+
+    @Column(name = "neutered", nullable = false)
+    private boolean neutered;
+
+    @Column(name = "birth_date")
+    private LocalDate birthDate;
+
+    @Column(name = "weight", precision = 5, scale = 1)
+    private BigDecimal weight;
+
+    @Column(name = "image_id")
+    private UUID imageId;
+
+    @Column(name = "notes", length = 200)
+    private String notes;
 }

--- a/mypawday/src/main/java/com/tico/mypawday/pet/domain/vo/Gender.java
+++ b/mypawday/src/main/java/com/tico/mypawday/pet/domain/vo/Gender.java
@@ -1,0 +1,21 @@
+package com.tico.mypawday.pet.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Gender {
+    MALE("수컷"),
+    FEMALE("암컷");
+
+    private final String description;
+
+    public static Gender from(String value) {
+        try {
+            return Gender.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 성별입니다: " + value);
+        }
+    }
+}

--- a/mypawday/src/main/java/com/tico/mypawday/pet/domain/vo/Species.java
+++ b/mypawday/src/main/java/com/tico/mypawday/pet/domain/vo/Species.java
@@ -1,0 +1,21 @@
+package com.tico.mypawday.pet.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Species {
+    DOG("강아지"),
+    CAT("고양이");
+
+    private final String description;
+
+    public static Species from(String value) {
+        try {
+            return Species.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 종족입니다: " + value);
+        }
+    }
+}


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
- #24 
- #23 

<br>

## 📌 개요
- 반려동물 도메인의 핵심 엔티티를 정의합니다.
- 반려동물(Pet)과 품종(Breed)을 도메인 엔티티로 구현하고,
  종(Species), 성별(Gender)은 Enum으로 분리하여 도메인 모델의 의미를 명확히 했습니다.

<br>

## 🔁 변경 사항
- Pet 도메인 엔티티 구현
- Breed 도메인 엔티티 구현
- Species Enum 추가 (반려동물 종 구분)
- Gender Enum 추가 (반려동물 성별 구분)

<br>

## 👀 기타 더 이야기해볼 점
- 품종(Breed)은 향후 도메인 확장 가능성을 고려하여 별도 엔티티로 분리했습니다.
- 반려동물 성별 명칭을 수컷/암컷 등 어떤 용어로 정의할지에 대해 논의가 필요합니다.