### PR TITLE
[feat] 산책일기(Walk) 도메인 엔티티 및 VO 구현

### DIFF
--- a/mypawday/src/main/java/com/tico/mypawday/pet/domain/vo/Gender.java
+++ b/mypawday/src/main/java/com/tico/mypawday/pet/domain/vo/Gender.java
@@ -12,6 +12,9 @@ public enum Gender {
     private final String description;
 
     public static Gender from(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("성별은 필수입니다.");
+        }
         try {
             return Gender.valueOf(value.toUpperCase());
         } catch (IllegalArgumentException e) {

--- a/mypawday/src/main/java/com/tico/mypawday/pet/domain/vo/Species.java
+++ b/mypawday/src/main/java/com/tico/mypawday/pet/domain/vo/Species.java
@@ -12,6 +12,9 @@ public enum Species {
     private final String description;
 
     public static Species from(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("종족은 필수입니다.");
+        }
         try {
             return Species.valueOf(value.toUpperCase());
         } catch (IllegalArgumentException e) {

--- a/mypawday/src/main/java/com/tico/mypawday/walk/domain/entity/Walk.java
+++ b/mypawday/src/main/java/com/tico/mypawday/walk/domain/entity/Walk.java
@@ -1,10 +1,17 @@
 package com.tico.mypawday.walk.domain.entity;
 
+import com.tico.mypawday.global.entity.BaseEntity;
+import com.tico.mypawday.walk.domain.vo.PoopInfo;
+import com.tico.mypawday.walk.domain.vo.Weather;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -14,10 +21,57 @@ import java.util.UUID;
 @Entity
 @Table(name = "p_walks")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Walk {
+public class Walk extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "walk_id")
+    @Column(name = "walk_id", nullable = false, updatable = false)
     private UUID walkId;
+
+    @Column(name = "user_id", nullable = false, updatable = false)
+    private UUID userId;
+
+    @Column(name = "walk_date", nullable = false)
+    private LocalDate walkDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "crossed_midnight", nullable = false)
+    private boolean crossedMidnight = false;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "weather", length = 20)
+    private Weather weather;
+
+    @Column(name = "route_description", length = 150)
+    private String routeDescription;
+
+    @Embedded
+    private PoopInfo poopInfo;
+
+    @Column(name = "friends_met", length = 100)
+    private String friendsMet;
+
+    @Column(name = "notes", length = 150)
+    private String notes;
+
+    @Column(name = "meals_snacks", length = 150)
+    private String mealsSnacks;
+
+    @Column(name = "diary", columnDefinition = "TEXT")
+    private String diary;
+
+    // 단방향 연관관계
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "walk_id")
+    private List<WalkPet> walkPets = new ArrayList<>();
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "walk_id")
+    @OrderBy("displayOrder ASC")
+    private List<WalkMedia> walkMediaList = new ArrayList<>();
 }

--- a/mypawday/src/main/java/com/tico/mypawday/walk/domain/entity/WalkMedia.java
+++ b/mypawday/src/main/java/com/tico/mypawday/walk/domain/entity/WalkMedia.java
@@ -1,5 +1,6 @@
 package com.tico.mypawday.walk.domain.entity;
 
+import com.tico.mypawday.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,10 +15,14 @@ import java.util.UUID;
 @Entity
 @Table(name = "p_walk_media")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WalkMedia {
+public class WalkMedia extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "media_id")
-    private UUID mediaId;
+    @Column(name = "media_id", nullable = false, updatable = false)
+    private UUID mediaId;  // 미디어 도메인 ID를 PK로 사용
+
+    @Column(name = "display_order", nullable = false)
+    private int displayOrder;
+
+    // walk_id는 Walk 엔티티의 @JoinColumn으로 관리됨
 }

--- a/mypawday/src/main/java/com/tico/mypawday/walk/domain/entity/WalkPet.java
+++ b/mypawday/src/main/java/com/tico/mypawday/walk/domain/entity/WalkPet.java
@@ -1,5 +1,7 @@
 package com.tico.mypawday.walk.domain.entity;
 
+import com.tico.mypawday.global.entity.BaseEntity;
+import com.tico.mypawday.walk.domain.vo.Condition;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -14,10 +16,22 @@ import java.util.UUID;
 @Entity
 @Table(name = "p_walk_pets")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class WalkPet {
+public class WalkPet extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "walk_pet_id")
+    @Column(name = "walk_pet_id", nullable = false, updatable = false)
     private UUID walkPetId;
+
+    @Column(name = "pet_id", nullable = false, updatable = false)
+    private UUID petId;
+
+    @Column(name = "pet_name", nullable = false, length = 15)
+    private String petName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "condition", nullable = false, length = 10)
+    private Condition condition;
+
+    // walk_id는 Walk 엔티티의 @JoinColumn으로 관리됨
 }

--- a/mypawday/src/main/java/com/tico/mypawday/walk/domain/vo/Condition.java
+++ b/mypawday/src/main/java/com/tico/mypawday/walk/domain/vo/Condition.java
@@ -1,0 +1,28 @@
+package com.tico.mypawday.walk.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 컨디션 Value Object
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Condition {
+    GOOD("좋음"),
+    NORMAL("보통"),
+    BAD("나쁨");
+
+    private final String description;
+
+    public static Condition from(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("컨디션은 필수입니다.");
+        }
+        try {
+            return Condition.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 컨디션입니다: " + value);
+        }
+    }
+}

--- a/mypawday/src/main/java/com/tico/mypawday/walk/domain/vo/PoopInfo.java
+++ b/mypawday/src/main/java/com/tico/mypawday/walk/domain/vo/PoopInfo.java
@@ -1,0 +1,28 @@
+package com.tico.mypawday.walk.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 배변 정보 Value Object
+ */
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PoopInfo {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "poop_status", length = 20)
+    private PoopStatus poopStatus;
+
+    @Column(name = "custom_poop_status", length = 50)
+    private String customPoopStatus;
+
+    @Column(name = "poop_notes", length = 100)
+    private String poopNotes;
+}

--- a/mypawday/src/main/java/com/tico/mypawday/walk/domain/vo/PoopStatus.java
+++ b/mypawday/src/main/java/com/tico/mypawday/walk/domain/vo/PoopStatus.java
@@ -1,0 +1,32 @@
+package com.tico.mypawday.walk.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 변 상태 Value Object
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PoopStatus {
+    NONE("배변 안 함"),
+    NORMAL("정상"),
+    SOFT("묽음"),
+    HARD("딱딱함"),
+    DIARRHEA("설사"),
+    BLOODY("혈변"),
+    CUSTOM("기타");
+
+    private final String description;
+
+    public static PoopStatus from(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return PoopStatus.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 배변 상태입니다: " + value);
+        }
+    }
+}

--- a/mypawday/src/main/java/com/tico/mypawday/walk/domain/vo/Weather.java
+++ b/mypawday/src/main/java/com/tico/mypawday/walk/domain/vo/Weather.java
@@ -1,0 +1,31 @@
+package com.tico.mypawday.walk.domain.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 날씨 Value Object
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Weather {
+    SUNNY("맑음"),
+    CLOUDY("흐림"),
+    RAINY("비"),
+    SNOWY("눈"),
+    WINDY("바람"),
+    LIGHTNING("천둥번개");
+
+    private final String description;
+
+    public static Weather from(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Weather.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("유효하지 않은 날씨입니다: " + value);
+        }
+    }
+}


### PR DESCRIPTION
## ❗️ 관련 이슈 링크
- #25 
- #23 

<br>

## 📌 개요
- 산책일기(Walk) 도메인의 애그리거트 구조를 정의하고 핵심 엔티티 및 VO를 구현했습니다.
- Walk를 애그리거트 루트로 설정하고, 산책에 참여한 반려동물은 `WalkPet` 연결 엔티티로 구성하여
  `Walk(1) : WalkPet(N)`, `Pet(1) : WalkPet(N)` 관계를 명확히 했습니다.
- 상태성 값은 Enum으로 분리하고, 배변 정보는 Value Object로 캡슐화했습니다.

<br>

## 🔁 변경 사항
- Walk 애그리거트 루트 엔티티 구현
- WalkMedia 엔티티 구현
- WalkPet 엔티티 구현
- Condition, Weather Enum 정의
- PoopInfo VO 및 PoopStatus Enum 구현

<br>

## 👀 기타 더 이야기해볼 점
